### PR TITLE
mathlib::data/nat dataset labeled

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ dataset statistics
 |basic   |1  |
 |analysis|1  |
 |group_theory| 2 |
+|rat    | 3|

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ dataset statistics
 |basic   |1  |
 |analysis|1  |
 |group_theory| 2 |
-|rat    | 3|
+|data/rat/basic.lean    | 72 |
+|data/rat/sqrt.lean | 3 |
+|data/rat/order.lean | 7 |

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ dataset statistics
 |--------|---|
 |basic   |1  |
 |analysis|1  |
+|group_theory| 2 |

--- a/data/rat/basic.lean
+++ b/data/rat/basic.lean
@@ -1,0 +1,903 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import data.equiv.encodable.basic
+import algebra.euclidean_domain
+import data.nat.gcd
+import data.int.cast
+
+/-!
+# Basics for the Rational Numbers
+
+## Summary
+
+We define a rational number `q` as a structure `{ num, denom, pos, cop }`, where
+- `num` is the numerator of `q`,
+- `denom` is the denominator of `q`,
+- `pos` is a proof that `denom > 0`, and
+- `cop` is a proof `num` and `denom` are coprime.
+
+We then define the expected (discrete) field structure on `ℚ` and prove basic lemmas about it.
+Moreoever, we provide the expected casts from `ℕ` and `ℤ` into `ℚ`, i.e. `(↑n : ℚ) = n / 1`.
+
+## Main Definitions
+
+- `rat` is the structure encoding `ℚ`.
+- `rat.mk n d` constructs a rational number `q = n / d` from `n d : ℤ`.
+
+## Notations
+
+- `/.` is infix notation for `rat.mk`.
+
+## Tags
+
+rat, rationals, field, ℚ, numerator, denominator, num, denom
+-/
+
+/-- `rat`, or `ℚ`, is the type of rational numbers. It is defined
+  as the set of pairs ⟨n, d⟩ of integers such that `d` is positive and `n` and
+  `d` are coprime. This representation is preferred to the quotient
+  because without periodic reduction, the numerator and denominator can grow
+  exponentially (for example, adding 1/2 to itself repeatedly). -/
+structure rat := mk' ::
+(num : ℤ)
+(denom : ℕ)
+(pos : 0 < denom)
+(cop : num.nat_abs.coprime denom)
+notation `ℚ` := rat
+
+namespace rat
+
+/-- String representation of a rational numbers, used in `has_repr`, `has_to_string`, and
+`has_to_format` instances. -/
+protected def repr : ℚ → string
+| ⟨n, d, _, _⟩ := if d = 1 then _root_.repr n else
+  _root_.repr n ++ "/" ++ _root_.repr d
+
+instance : has_repr ℚ := ⟨rat.repr⟩
+instance : has_to_string ℚ := ⟨rat.repr⟩
+meta instance : has_to_format ℚ := ⟨coe ∘ rat.repr⟩
+
+instance : encodable ℚ := encodable.of_equiv (Σ n : ℤ, {d : ℕ // 0 < d ∧ n.nat_abs.coprime d})
+  ⟨λ ⟨a, b, c, d⟩, ⟨a, b, c, d⟩, λ⟨a, b, c, d⟩, ⟨a, b, c, d⟩,
+   λ ⟨a, b, c, d⟩, rfl, λ⟨a, b, c, d⟩, rfl⟩
+
+/-- Embed an integer as a rational number -/
+def of_int (n : ℤ) : ℚ :=
+⟨n, 1, nat.one_pos, nat.coprime_one_right _⟩
+
+instance : has_zero ℚ := ⟨of_int 0⟩
+instance : has_one ℚ := ⟨of_int 1⟩
+instance : inhabited ℚ := ⟨0⟩
+
+/-* Two rational numbers are equal if and only if their numerators are equal and their denominators are equal. *-/
+lemma ext_iff {p q : ℚ} : p = q ↔ p.num = q.num ∧ p.denom = q.denom :=
+by { cases p, cases q, simp }
+
+/-* Let $p, q$ be two raional numbers. If the numerator of $p$ equals to that of $q$, 
+and the denominator of $p$ equals to the denominator of $q$, then $p$ equals to $q$. *-/
+@[ext] lemma ext {p q : ℚ} (hn : p.num = q.num) (hd : p.denom = q.denom) : p = q :=
+rat.ext_iff.mpr ⟨hn, hd⟩
+
+/-- Form the quotient `n / d` where `n:ℤ` and `d:ℕ+` (not necessarily coprime) -/
+def mk_pnat (n : ℤ) : ℕ+ → ℚ | ⟨d, dpos⟩ :=
+let n' := n.nat_abs, g := n'.gcd d in
+⟨n / g, d / g, begin
+  apply (nat.le_div_iff_mul_le _ _ (nat.gcd_pos_of_pos_right _ dpos)).2,
+  simp, exact nat.le_of_dvd dpos (nat.gcd_dvd_right _ _)
+end, begin
+  have : int.nat_abs (n / ↑g) = n' / g,
+  { cases int.nat_abs_eq n with e e; rw e, { refl },
+    rw [int.neg_div_of_dvd, int.nat_abs_neg], { refl },
+    exact int.coe_nat_dvd.2 (nat.gcd_dvd_left _ _) },
+  rw this,
+  exact nat.coprime_div_gcd_div_gcd (nat.gcd_pos_of_pos_right _ dpos)
+end⟩
+
+/-- Form the quotient `n / d` where `n:ℤ` and `d:ℕ`. In the case `d = 0`, we
+  define `n / 0 = 0` by convention. -/
+def mk_nat (n : ℤ) (d : ℕ) : ℚ :=
+if d0 : d = 0 then 0 else mk_pnat n ⟨d, nat.pos_of_ne_zero d0⟩
+
+/-- Form the quotient `n / d` where `n d : ℤ`. -/
+def mk : ℤ → ℤ → ℚ
+| n (d : ℕ) := mk_nat n d
+| n -[1+ d] := mk_pnat (-n) d.succ_pnat
+
+localized "infix ` /. `:70 := rat.mk" in rat
+
+theorem mk_pnat_eq (n d h) : mk_pnat n ⟨d, h⟩ = n /. d :=
+by change n /. d with dite _ _ _; simp [ne_of_gt h]
+
+theorem mk_nat_eq (n d) : mk_nat n d = n /. d := rfl
+
+@[simp] theorem mk_zero (n) : n /. 0 = 0 := rfl
+
+@[simp] theorem zero_mk_pnat (n) : mk_pnat 0 n = 0 :=
+by cases n; simp [mk_pnat]; change int.nat_abs 0 with 0; simp *; refl
+
+@[simp] theorem zero_mk_nat (n) : mk_nat 0 n = 0 :=
+by by_cases n = 0; simp [*, mk_nat]
+
+/-* Zero over any number is zero. *-/
+@[simp] theorem zero_mk (n) : 0 /. n = 0 :=
+by cases n; simp [mk]
+
+private lemma gcd_abs_dvd_left {a b} : (nat.gcd (int.nat_abs a) b : ℤ) ∣ a :=
+int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $ nat.gcd_dvd_left (int.nat_abs a) b
+
+/-* Let $a, b$ be two integers, and $b$ is not zero, then that $a$ over $b$ equals to zero implies $a$ is zero. *-/
+@[simp] theorem mk_eq_zero {a b : ℤ} (b0 : b ≠ 0) : a /. b = 0 ↔ a = 0 :=
+begin
+  constructor; intro h; [skip, {subst a, simp}],
+  have : ∀ {a b}, mk_pnat a b = 0 → a = 0,
+  { intros a b e, cases b with b h,
+    injection e with e,
+    apply int.eq_mul_of_div_eq_right gcd_abs_dvd_left e },
+  cases b with b; simp [mk, mk_nat] at h,
+  { simp [mt (congr_arg int.of_nat) b0] at h,
+    exact this h },
+  { apply neg_injective, simp [this h] }
+end
+
+/-* Let $a, b, c, d$ be four integers, where $b, d$ are nonzero, then $a$ over $b$ equals $c$ over $d$,
+if and only if $a$ times $d$ equals to $c$ times $b$. *-/
+theorem mk_eq : ∀ {a b c d : ℤ} (hb : b ≠ 0) (hd : d ≠ 0),
+  a /. b = c /. d ↔ a * d = c * b :=
+suffices ∀ a b c d hb hd, mk_pnat a ⟨b, hb⟩ = mk_pnat c ⟨d, hd⟩ ↔ a * d = c * b,
+begin
+  intros, cases b with b b; simp [mk, mk_nat, nat.succ_pnat],
+  simp [mt (congr_arg int.of_nat) hb],
+  all_goals
+  { cases d with d d; simp [mk, mk_nat, nat.succ_pnat],
+    simp [mt (congr_arg int.of_nat) hd],
+    all_goals { rw this, try {refl} } },
+  { change a * ↑(d.succ) = -c * ↑b ↔ a * -(d.succ) = c * b,
+    constructor; intro h; apply neg_injective; simpa [left_distrib, neg_add_eq_iff_eq_add,
+      eq_neg_iff_add_eq_zero, neg_eq_iff_add_eq_zero] using h },
+  { change -a * ↑d = c * b.succ ↔ a * d = c * -b.succ,
+    constructor; intro h; apply neg_injective; simpa [left_distrib, eq_comm] using h },
+  { change -a * d.succ = -c * b.succ ↔ a * -d.succ = c * -b.succ,
+    simp [left_distrib, sub_eq_add_neg], cc }
+end,
+begin
+  intros, simp [mk_pnat], constructor; intro h,
+  { cases h with ha hb,
+    have ha,
+    { have dv := @gcd_abs_dvd_left,
+      have := int.eq_mul_of_div_eq_right dv ha,
+      rw ← int.mul_div_assoc _ dv at this,
+      exact int.eq_mul_of_div_eq_left (dv.mul_left _) this.symm },
+    have hb,
+    { have dv := λ {a b}, nat.gcd_dvd_right (int.nat_abs a) b,
+      have := nat.eq_mul_of_div_eq_right dv hb,
+      rw ← nat.mul_div_assoc _ dv at this,
+      exact nat.eq_mul_of_div_eq_left (dv.mul_left _) this.symm },
+    have m0 : (a.nat_abs.gcd b * c.nat_abs.gcd d : ℤ) ≠ 0,
+    { refine int.coe_nat_ne_zero.2 (ne_of_gt _),
+      apply mul_pos; apply nat.gcd_pos_of_pos_right; assumption },
+    apply mul_right_cancel₀ m0,
+    simpa [mul_comm, mul_left_comm] using
+      congr (congr_arg (*) ha.symm) (congr_arg coe hb) },
+  { suffices : ∀ a c, a * d = c * b →
+      a / a.gcd b = c / c.gcd d ∧ b / a.gcd b = d / c.gcd d,
+    { cases this a.nat_abs c.nat_abs
+        (by simpa [int.nat_abs_mul] using congr_arg int.nat_abs h) with h₁ h₂,
+      have hs := congr_arg int.sign h,
+      simp [int.sign_eq_one_of_pos (int.coe_nat_lt.2 hb),
+            int.sign_eq_one_of_pos (int.coe_nat_lt.2 hd)] at hs,
+      conv in a { rw ← int.sign_mul_nat_abs a },
+      conv in c { rw ← int.sign_mul_nat_abs c },
+      rw [int.mul_div_assoc, int.mul_div_assoc],
+      exact ⟨congr (congr_arg (*) hs) (congr_arg coe h₁), h₂⟩,
+      all_goals { exact int.coe_nat_dvd.2 (nat.gcd_dvd_left _ _) } },
+    intros a c h,
+    suffices bd : b / a.gcd b = d / c.gcd d,
+    { refine ⟨_, bd⟩,
+      apply nat.eq_of_mul_eq_mul_left hb,
+      rw [← nat.mul_div_assoc _ (nat.gcd_dvd_left _ _), mul_comm,
+          nat.mul_div_assoc _ (nat.gcd_dvd_right _ _), bd,
+          ← nat.mul_div_assoc _ (nat.gcd_dvd_right _ _), h, mul_comm,
+          nat.mul_div_assoc _ (nat.gcd_dvd_left _ _)] },
+    suffices : ∀ {a c : ℕ} (b>0) (d>0),
+      a * d = c * b → b / a.gcd b ≤ d / c.gcd d,
+    { exact le_antisymm (this _ hb _ hd h) (this _ hd _ hb h.symm) },
+    intros a c b hb d hd h,
+    have gb0 := nat.gcd_pos_of_pos_right a hb,
+    have gd0 := nat.gcd_pos_of_pos_right c hd,
+    apply nat.le_of_dvd,
+    apply (nat.le_div_iff_mul_le _ _ gd0).2,
+    simp, apply nat.le_of_dvd hd (nat.gcd_dvd_right _ _),
+    apply (nat.coprime_div_gcd_div_gcd gb0).symm.dvd_of_dvd_mul_left,
+    refine ⟨c / c.gcd d, _⟩,
+    rw [← nat.mul_div_assoc _ (nat.gcd_dvd_left _ _),
+        ← nat.mul_div_assoc _ (nat.gcd_dvd_right _ _)],
+    apply congr_arg (/ c.gcd d),
+    rw [mul_comm, ← nat.mul_div_assoc _ (nat.gcd_dvd_left _ _),
+        mul_comm, h, nat.mul_div_assoc _ (nat.gcd_dvd_right _ _), mul_comm] }
+end
+
+/-* Let $a, b, c$ be three integers, where $c$ is not zero, then $a * c$ over $b * c$ equals to
+$a$ over $c$. *-/
+@[simp] theorem div_mk_div_cancel_left {a b c : ℤ} (c0 : c ≠ 0) :
+  (a * c) /. (b * c) = a /. b :=
+begin
+  by_cases b0 : b = 0, { subst b0, simp },
+  apply (mk_eq (mul_ne_zero b0 c0) b0).2, simp [mul_comm, mul_assoc]
+end
+
+@[simp] theorem num_denom : ∀ {a : ℚ}, a.num /. a.denom = a
+| ⟨n, d, h, (c:_=1)⟩ := show mk_nat n d = _,
+  by simp [mk_nat, ne_of_gt h, mk_pnat, c]
+
+theorem num_denom' {n d h c} : (⟨n, d, h, c⟩ : ℚ) = n /. d := num_denom.symm
+
+theorem of_int_eq_mk (z : ℤ) : of_int z = z /. 1 := num_denom'
+
+/-- Define a (dependent) function or prove `∀ r : ℚ, p r` by dealing with rational
+numbers of the form `n /. d` with `0 < d` and coprime `n`, `d`. -/
+@[elab_as_eliminator] def {u} num_denom_cases_on {C : ℚ → Sort u}
+   : ∀ (a : ℚ) (H : ∀ n d, 0 < d → (int.nat_abs n).coprime d → C (n /. d)), C a
+| ⟨n, d, h, c⟩ H := by rw num_denom'; exact H n d h c
+
+/-- Define a (dependent) function or prove `∀ r : ℚ, p r` by dealing with rational
+numbers of the form `n /. d` with `d ≠ 0`. -/
+@[elab_as_eliminator] def {u} num_denom_cases_on' {C : ℚ → Sort u}
+   (a : ℚ) (H : ∀ (n:ℤ) (d:ℕ), d ≠ 0 → C (n /. d)) : C a :=
+num_denom_cases_on a $ λ n d h c, H n d h.ne'
+
+/-* The numerator of $a$ over $b$ divides $a$. *-/
+theorem num_dvd (a) {b : ℤ} (b0 : b ≠ 0) : (a /. b).num ∣ a :=
+begin
+  cases e : a /. b with n d h c,
+  rw [rat.num_denom', rat.mk_eq b0
+    (ne_of_gt (int.coe_nat_pos.2 h))] at e,
+  refine (int.nat_abs_dvd.1 $ int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $
+    c.dvd_of_dvd_mul_right _),
+  have := congr_arg int.nat_abs e,
+  simp [int.nat_abs_mul, int.nat_abs_of_nat] at this, simp [this]
+end
+
+/-* The denominator of $a$ over $b$ divides $b$. *-/
+theorem denom_dvd (a b : ℤ) : ((a /. b).denom : ℤ) ∣ b :=
+begin
+  by_cases b0 : b = 0, {simp [b0]},
+  cases e : a /. b with n d h c,
+  rw [num_denom', mk_eq b0 (ne_of_gt (int.coe_nat_pos.2 h))] at e,
+  refine (int.dvd_nat_abs.1 $ int.coe_nat_dvd.2 $ c.symm.dvd_of_dvd_mul_left _),
+  rw [← int.nat_abs_mul, ← int.coe_nat_dvd, int.dvd_nat_abs, ← e], simp
+end
+
+/-- Addition of rational numbers. Use `(+)` instead. -/
+protected def add : ℚ → ℚ → ℚ
+| ⟨n₁, d₁, h₁, c₁⟩ ⟨n₂, d₂, h₂, c₂⟩ := mk_pnat (n₁ * d₂ + n₂ * d₁) ⟨d₁ * d₂, mul_pos h₁ h₂⟩
+
+instance : has_add ℚ := ⟨rat.add⟩
+
+theorem lift_binop_eq (f : ℚ → ℚ → ℚ) (f₁ : ℤ → ℤ → ℤ → ℤ → ℤ) (f₂ : ℤ → ℤ → ℤ → ℤ → ℤ)
+  (fv : ∀ {n₁ d₁ h₁ c₁ n₂ d₂ h₂ c₂},
+    f ⟨n₁, d₁, h₁, c₁⟩ ⟨n₂, d₂, h₂, c₂⟩ = f₁ n₁ d₁ n₂ d₂ /. f₂ n₁ d₁ n₂ d₂)
+  (f0 : ∀ {n₁ d₁ n₂ d₂} (d₁0 : d₁ ≠ 0) (d₂0 : d₂ ≠ 0), f₂ n₁ d₁ n₂ d₂ ≠ 0)
+  (a b c d : ℤ) (b0 : b ≠ 0) (d0 : d ≠ 0)
+  (H : ∀ {n₁ d₁ n₂ d₂} (h₁ : a * d₁ = n₁ * b) (h₂ : c * d₂ = n₂ * d),
+       f₁ n₁ d₁ n₂ d₂ * f₂ a b c d = f₁ a b c d * f₂ n₁ d₁ n₂ d₂) :
+  f (a /. b) (c /. d) = f₁ a b c d /. f₂ a b c d :=
+begin
+  generalize ha : a /. b = x, cases x with n₁ d₁ h₁ c₁, rw num_denom' at ha,
+  generalize hc : c /. d = x, cases x with n₂ d₂ h₂ c₂, rw num_denom' at hc,
+  rw fv,
+  have d₁0 := ne_of_gt (int.coe_nat_lt.2 h₁),
+  have d₂0 := ne_of_gt (int.coe_nat_lt.2 h₂),
+  exact (mk_eq (f0 d₁0 d₂0) (f0 b0 d0)).2 (H ((mk_eq b0 d₁0).1 ha) ((mk_eq d0 d₂0).1 hc))
+end
+
+/-* Let $a, b, c, d$ be four intgers, and $b, d$ are nonzero. 
+The sum of $a / b$ and $c / d$ is equal to $a * d + c * b$ over $b * d$. *-/
+@[simp] theorem add_def {a b c d : ℤ} (b0 : b ≠ 0) (d0 : d ≠ 0) :
+  a /. b + c /. d = (a * d + c * b) /. (b * d) :=
+begin
+  apply lift_binop_eq rat.add; intros; try {assumption},
+  { apply mk_pnat_eq },
+  { apply mul_ne_zero d₁0 d₂0 },
+  calc (n₁ * d₂ + n₂ * d₁) * (b * d) =
+          (n₁ * b) * d₂ * d + (n₂ * d) * (d₁ * b) : by simp [mul_add, mul_comm, mul_left_comm]
+    ... = (a * d₁) * d₂ * d + (c * d₂) * (d₁ * b) : by rw [h₁, h₂]
+    ... = (a * d + c * b) * (d₁ * d₂)             : by simp [mul_add, mul_comm, mul_left_comm]
+end
+
+/-- Negation of rational numbers. Use `-r` instead. -/
+protected def neg (r : ℚ) : ℚ :=
+⟨-r.num, r.denom, r.pos, by simp [r.cop]⟩
+
+instance : has_neg ℚ := ⟨rat.neg⟩
+
+/-* Let $a, b$ be two integers, then the negative number of $a$ over $b$ equals to
+$-a$ over $b$. *-/
+@[simp] theorem neg_def {a b : ℤ} : -(a /. b) = -a /. b :=
+begin
+  by_cases b0 :  b = 0, { subst b0, simp, refl },
+  generalize ha : a /. b = x, cases x with n₁ d₁ h₁ c₁, rw num_denom' at ha,
+  show rat.mk' _ _ _ _ = _, rw num_denom',
+  have d0 := ne_of_gt (int.coe_nat_lt.2 h₁),
+  apply (mk_eq d0 b0).2, have h₁ := (mk_eq b0 d0).1 ha,
+  simp only [neg_mul, congr_arg has_neg.neg h₁]
+end
+
+/-* Let $n, d$ be two integers, then $n$ over $-d$ is euqal to $-n$ over $d$. *-/
+@[simp] lemma mk_neg_denom (n d : ℤ) : n /. -d = -n /. d :=
+begin
+  by_cases hd : d = 0;
+  simp [rat.mk_eq, hd]
+end
+
+/-- Multiplication of rational numbers. Use `(*)` instead. -/
+protected def mul : ℚ → ℚ → ℚ
+| ⟨n₁, d₁, h₁, c₁⟩ ⟨n₂, d₂, h₂, c₂⟩ := mk_pnat (n₁ * n₂) ⟨d₁ * d₂, mul_pos h₁ h₂⟩
+
+instance : has_mul ℚ := ⟨rat.mul⟩
+
+/-* Let $a, b, c, d$ be four integers, and $b, d$ are nonzero.
+Then $a / b$ times $c / d$ equals to $a * c$ over $b * d$. *-/
+@[simp] theorem mul_def {a b c d : ℤ} (b0 : b ≠ 0) (d0 : d ≠ 0) :
+  (a /. b) * (c /. d) = (a * c) /. (b * d) :=
+begin
+  apply lift_binop_eq rat.mul; intros; try {assumption},
+  { apply mk_pnat_eq },
+  { apply mul_ne_zero d₁0 d₂0 },
+  cc
+end
+
+/-- Inverse rational number. Use `r⁻¹` instead. -/
+protected def inv : ℚ → ℚ
+| ⟨(n+1:ℕ), d, h, c⟩ := ⟨d, n+1, n.succ_pos, c.symm⟩
+| ⟨0, d, h, c⟩ := 0
+| ⟨-[1+ n], d, h, c⟩ := ⟨-d, n+1, n.succ_pos, nat.coprime.symm $ by simp; exact c⟩
+
+instance : has_inv ℚ := ⟨rat.inv⟩
+
+/-* Let $a, b$ be two integers, then the inverse of $a / b$ is $b / a$. *-/
+@[simp] theorem inv_def {a b : ℤ} : (a /. b)⁻¹ = b /. a :=
+begin
+  by_cases a0 : a = 0, { subst a0, simp, refl },
+  by_cases b0 : b = 0, { subst b0, simp, refl },
+  generalize ha : a /. b = x, cases x with n d h c, rw num_denom' at ha,
+  refine eq.trans (_ : rat.inv ⟨n, d, h, c⟩ = d /. n) _,
+  { cases n with n; [cases n with n, skip],
+    { refl },
+    { change int.of_nat n.succ with (n+1:ℕ),
+      unfold rat.inv, rw num_denom' },
+    { unfold rat.inv, rw num_denom', refl } },
+  have n0 : n ≠ 0,
+  { refine mt (λ (n0 : n = 0), _) a0,
+    subst n0, simp at ha,
+    exact (mk_eq_zero b0).1 ha },
+  have d0 := ne_of_gt (int.coe_nat_lt.2 h),
+  have ha := (mk_eq b0 d0).1 ha,
+  apply (mk_eq n0 a0).2,
+  cc
+end
+
+variables (a b c : ℚ)
+
+/-* Any rational number is euqal to the sum of itself and zero. *-/
+protected theorem add_zero : a + 0 = a :=
+num_denom_cases_on' a $ λ n d h,
+by rw [← zero_mk d]; simp [h, -zero_mk]
+
+/-* Any rational number is equal to the sum of zero and itself. *-/
+protected theorem zero_add : 0 + a = a :=
+num_denom_cases_on' a $ λ n d h,
+by rw [← zero_mk d]; simp [h, -zero_mk]
+
+/-* Let $a, b$ be two rational numbers, then $a + b$ euqals to $b + a$. *-/
+protected theorem add_comm : a + b = b + a :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+by simp [h₁, h₂]; cc
+
+/-* Let $a, b, c$ be three rational numbers, then $a + b + c$ equals to $a$ plus $(b + c)$. *-/
+protected theorem add_assoc : a + b + c = a + (b + c) :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+num_denom_cases_on' c $ λ n₃ d₃ h₃,
+by simp [h₁, h₂, h₃, mul_ne_zero, mul_add, mul_comm, mul_left_comm, add_left_comm, add_assoc]
+
+/-* Let $a$ be a rational number, then $-a$ plus $a$ equals to zero. *-/
+protected theorem add_left_neg : -a + a = 0 :=
+num_denom_cases_on' a $ λ n d h,
+by simp [h]
+
+/-* Zero over one is zero. *-/
+@[simp] lemma mk_zero_one : 0 /. 1 = 0 :=
+show mk_pnat _ _ = _, by { rw mk_pnat, simp, refl }
+
+/-* One over one is one. *-/
+@[simp] lemma mk_one_one : 1 /. 1 = 1 :=
+show mk_pnat _ _ = _, by { rw mk_pnat, simp, refl }
+
+/-* $-1$ over 1 is $-1$. *-/
+@[simp] lemma mk_neg_one_one : (-1) /. 1 = -1 :=
+show mk_pnat _ _ = _, by { rw mk_pnat, simp, refl }
+
+/-* An rational number times one is itself. *-/
+protected theorem mul_one : a * 1 = a :=
+num_denom_cases_on' a $ λ n d h,
+by { rw ← mk_one_one, simp [h, -mk_one_one] }
+
+/-* One times any rational number equals to that rational number. *-/
+protected theorem one_mul : 1 * a = a :=
+num_denom_cases_on' a $ λ n d h,
+by { rw ← mk_one_one, simp [h, -mk_one_one] }
+
+/-* Let $a, b$ be two rational numbers, then $a * b$ equals to $b * a$. *-/
+protected theorem mul_comm : a * b = b * a :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+by simp [h₁, h₂, mul_comm]
+
+/-* Let $a, b, c$ be three rational numbers, then $a * b * c$ equals to $a$ times $(b * c)$. *-/
+protected theorem mul_assoc : a * b * c = a * (b * c) :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+num_denom_cases_on' c $ λ n₃ d₃ h₃,
+by simp [h₁, h₂, h₃, mul_ne_zero, mul_comm, mul_left_comm]
+
+/-* Let $a, b, c$ be three rational numbers, then $a + b$ times $c$ equals to $a * c$ plus $b * c$. *-/
+protected theorem add_mul : (a + b) * c = a * c + b * c :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+num_denom_cases_on' c $ λ n₃ d₃ h₃,
+by simp [h₁, h₂, h₃, mul_ne_zero];
+   refine (div_mk_div_cancel_left (int.coe_nat_ne_zero.2 h₃)).symm.trans _;
+   simp [mul_add, mul_comm, mul_assoc, mul_left_comm]
+
+/-* Let $a, b, c$ be three rational numbers, then $a$ times $b + c$ equals to $a * b$ plus $a * c$. *-/
+protected theorem mul_add : a * (b + c) = a * b + a * c :=
+by rw [rat.mul_comm, rat.add_mul, rat.mul_comm, rat.mul_comm c a]
+
+/-* Zero is not equal to one. *-/
+protected theorem zero_ne_one : 0 ≠ (1:ℚ) :=
+suffices (1:ℚ) = 0 → false, by cc,
+by { rw [← mk_one_one, mk_eq_zero one_ne_zero], exact one_ne_zero }
+
+/-* For a nonzero rational number $a$, the inverse of $a$ times $a$ is one. *-/
+protected theorem mul_inv_cancel : a ≠ 0 → a * a⁻¹ = 1 :=
+num_denom_cases_on' a $ λ n d h a0,
+have n0 : n ≠ 0, from mt (by intro e; subst e; simp) a0,
+by simpa [h, n0, mul_comm] using @div_mk_div_cancel_left 1 1 _ n0
+
+/-* For a nonzero rational number $a$, $a$ times inverse of $a$ is one. *-/
+protected theorem inv_mul_cancel (h : a ≠ 0) : a⁻¹ * a = 1 :=
+eq.trans (rat.mul_comm _ _) (rat.mul_inv_cancel _ h)
+
+instance : decidable_eq ℚ := by tactic.mk_dec_eq_instance
+
+instance : field ℚ :=
+{ zero             := 0,
+  add              := rat.add,
+  neg              := rat.neg,
+  one              := 1,
+  mul              := rat.mul,
+  inv              := rat.inv,
+  zero_add         := rat.zero_add,
+  add_zero         := rat.add_zero,
+  add_comm         := rat.add_comm,
+  add_assoc        := rat.add_assoc,
+  add_left_neg     := rat.add_left_neg,
+  mul_one          := rat.mul_one,
+  one_mul          := rat.one_mul,
+  mul_comm         := rat.mul_comm,
+  mul_assoc        := rat.mul_assoc,
+  left_distrib     := rat.mul_add,
+  right_distrib    := rat.add_mul,
+  exists_pair_ne   := ⟨0, 1, rat.zero_ne_one⟩,
+  mul_inv_cancel   := rat.mul_inv_cancel,
+  inv_zero         := rfl }
+
+/- Extra instances to short-circuit type class resolution -/
+instance : division_ring ℚ      := by apply_instance
+instance : is_domain ℚ          := by apply_instance
+-- TODO(Mario): this instance slows down data.real.basic
+instance : nontrivial ℚ         := by apply_instance
+instance : comm_ring ℚ          := by apply_instance
+--instance : ring ℚ             := by apply_instance
+instance : comm_semiring ℚ      := by apply_instance
+instance : semiring ℚ           := by apply_instance
+instance : add_comm_group ℚ     := by apply_instance
+instance : add_group ℚ          := by apply_instance
+instance : add_comm_monoid ℚ    := by apply_instance
+instance : add_monoid ℚ         := by apply_instance
+instance : add_left_cancel_semigroup ℚ := by apply_instance
+instance : add_right_cancel_semigroup ℚ := by apply_instance
+instance : add_comm_semigroup ℚ := by apply_instance
+instance : add_semigroup ℚ      := by apply_instance
+instance : comm_monoid ℚ        := by apply_instance
+instance : monoid ℚ             := by apply_instance
+instance : comm_semigroup ℚ     := by apply_instance
+instance : semigroup ℚ          := by apply_instance
+
+/-* Let $a, b, c, d$ be four integers, then $a / b$ minus $c / d$ equals to $a * d - c * b$ over $b * d$. *-/
+theorem sub_def {a b c d : ℤ} (b0 : b ≠ 0) (d0 : d ≠ 0) :
+  a /. b - c /. d = (a * d - c * b) /. (b * d) :=
+by simp [b0, d0, sub_eq_add_neg]
+
+/-* Let $q$ be a rational number, then the denominator of $q$ equals to the denominator of $-q$. *-/
+@[simp] lemma denom_neg_eq_denom (q : ℚ) : (-q).denom = q.denom := rfl
+
+/-* Let $q$ be a rational number, then the numerator of $-q$ equals to the nagative denominator of $q$. *-/
+@[simp] lemma num_neg_eq_neg_num (q : ℚ) : (-q).num = -(q.num) := rfl
+
+/-* The numerator of 0 is 0. *-/
+@[simp] lemma num_zero : rat.num 0 = 0 := rfl
+
+/-* The denominator of 0 is 1. *-/
+@[simp] lemma denom_zero : rat.denom 0 = 1 := rfl
+
+/-* Let $q$ be a rational number, then that the numerator of $q$ is zero implies $q$ is zero. *-/
+lemma zero_of_num_zero {q : ℚ} (hq : q.num = 0) : q = 0 :=
+have q = q.num /. q.denom, from num_denom.symm,
+by simpa [hq]
+
+/-* Let $q$ be a rational number, then $q$ is zero if and only if the numerator of $q$ is zero. *-/
+lemma zero_iff_num_zero {q : ℚ} : q = 0 ↔ q.num = 0 :=
+⟨λ _, by simp *, zero_of_num_zero⟩
+
+/-* Let $q$ be a rational number, then $q$ is nonzero if and only if the numerator of $q$ is nonzero. *-/
+lemma num_ne_zero_of_ne_zero {q : ℚ} (h : q ≠ 0) : q.num ≠ 0 :=
+assume : q.num = 0,
+h $ zero_of_num_zero this
+
+/-* The numerator of 1 is 1. *-/
+@[simp] lemma num_one : (1 : ℚ).num = 1 := rfl
+
+/-* The denominator of 1 is 1. *-/
+@[simp] lemma denom_one : (1 : ℚ).denom = 1 := rfl
+
+/-* The denominator of any rational number cannot be zero. *-/
+lemma denom_ne_zero (q : ℚ) : q.denom ≠ 0 :=
+ne_of_gt q.pos
+
+/-* Let $p, q$ be rational, then $p = q$ if and only if the numerator of $p$ times the denominator of $q$ equals to
+the numerator of $q$ times the denominator of $p$. *-/
+lemma eq_iff_mul_eq_mul {p q : ℚ} : p = q ↔ p.num * q.denom = q.num * p.denom :=
+begin
+  conv_lhs { rw [←(@num_denom p), ←(@num_denom q)] },
+  apply rat.mk_eq,
+  { exact_mod_cast p.denom_ne_zero },
+  { exact_mod_cast q.denom_ne_zero }
+end
+
+/-* Let $n, d$ be integers, $q = n / d$, then $q$ is not zero implies $n$ is not zero. *-/
+lemma mk_num_ne_zero_of_ne_zero {q : ℚ} {n d : ℤ} (hq : q ≠ 0) (hqnd : q = n /. d) : n ≠ 0 :=
+assume : n = 0,
+hq $ by simpa [this] using hqnd
+
+/-* Let $n, d$ be integers, $q = n / d$, then $q$ is not zero implies $d$ is not zero. *-/
+lemma mk_denom_ne_zero_of_ne_zero {q : ℚ} {n d : ℤ} (hq : q ≠ 0) (hqnd : q = n /. d) : d ≠ 0 :=
+assume : d = 0,
+hq $ by simpa [this] using hqnd
+
+/-* Let $n, d$ be nonzero integers, then $n / d$ is nonzero. *-/
+lemma mk_ne_zero_of_ne_zero {n d : ℤ} (h : n ≠ 0) (hd : d ≠ 0) : n /. d ≠ 0 :=
+assume : n /. d = 0,
+h $ (mk_eq_zero hd).1 this
+
+/-* Let $q, r$ be rational, then $q * r$ equals to the multiplication of their numerators over
+the multiplication of their denominators. *-/
+lemma mul_num_denom (q r : ℚ) : q * r = (q.num * r.num) /. ↑(q.denom * r.denom) :=
+have hq' : (↑q.denom : ℤ) ≠ 0, by have := denom_ne_zero q; simpa,
+have hr' : (↑r.denom : ℤ) ≠ 0, by have := denom_ne_zero r; simpa,
+suffices (q.num /. ↑q.denom) * (r.num /. ↑r.denom) = (q.num * r.num) /. ↑(q.denom * r.denom),
+  by simpa using this,
+by simp [mul_def hq' hr', -num_denom]
+
+/-* Let $q, r$ be rational, then $q / r$ equals to the numerator of $q$ times the denominator of $r$ over
+the multiplication of the denominator of $q$ and the numerator of $r$. *-/
+lemma div_num_denom (q r : ℚ) : q / r = (q.num * r.denom) /. (q.denom * r.num) :=
+if hr : r.num = 0 then
+  have hr' : r = 0, from zero_of_num_zero hr,
+  by simp *
+else
+  calc q / r = q * r⁻¹ : div_eq_mul_inv q r
+         ... = (q.num /. q.denom) * (r.num /. r.denom)⁻¹ : by simp
+         ... = (q.num /. q.denom) * (r.denom /. r.num) : by rw inv_def
+         ... = (q.num * r.denom) /. (q.denom * r.num) : mul_def (by simpa using denom_ne_zero q) hr
+
+/-* Let $n, d$ be nonzero integers, and $q$ be $n / d$, then there exists an integer $z$ such that
+$n$ equals to $c$ times the numerator of $q$ and $d$ equals to $c$ times the denominator of $q$. *-/
+lemma num_denom_mk {q : ℚ} {n d : ℤ} (hn : n ≠ 0) (hd : d ≠ 0) (qdf : q = n /. d) :
+      ∃ c : ℤ, n = c * q.num ∧ d = c * q.denom :=
+have hq : q ≠ 0, from
+  assume : q = 0,
+  hn $ (rat.mk_eq_zero hd).1 (by cc),
+have q.num /. q.denom = n /. d, by rwa [num_denom],
+have q.num * d = n * ↑(q.denom), from (rat.mk_eq (by simp [rat.denom_ne_zero]) hd).1 this,
+begin
+  existsi n / q.num,
+  have hqdn : q.num ∣ n, begin rw qdf, apply rat.num_dvd, assumption end,
+  split,
+  { rw int.div_mul_cancel hqdn },
+  { apply int.eq_mul_div_of_mul_eq_mul_of_dvd_left,
+    { apply rat.num_ne_zero_of_ne_zero hq },
+    repeat { assumption } }
+end
+
+theorem mk_pnat_num (n : ℤ) (d : ℕ+) :
+  (mk_pnat n d).num = n / nat.gcd n.nat_abs d :=
+by cases d; refl
+
+theorem mk_pnat_denom (n : ℤ) (d : ℕ+) :
+  (mk_pnat n d).denom = d / nat.gcd n.nat_abs d :=
+by cases d; refl
+
+lemma num_mk (n d : ℤ) :
+  (n /. d).num = d.sign * n / n.gcd d :=
+begin
+  rcases d with ((_ | _) | _),
+  { simp },
+  { simpa [←int.coe_nat_succ, int.sign_coe_nat_of_nonzero] },
+  { rw rat.mk,
+    simpa [rat.mk_pnat_num, int.neg_succ_of_nat_eq, ←int.coe_nat_succ,
+           int.sign_coe_nat_of_nonzero] }
+end
+
+lemma denom_mk (n d : ℤ) :
+  (n /. d).denom = if d = 0 then 1 else d.nat_abs / n.gcd d :=
+begin
+  rcases d with ((_ | _) | _),
+  { simp },
+  { simpa [←int.coe_nat_succ, int.sign_coe_nat_of_nonzero] },
+  { rw rat.mk,
+    simpa [rat.mk_pnat_denom, int.neg_succ_of_nat_eq, ←int.coe_nat_succ,
+           int.sign_coe_nat_of_nonzero] }
+end
+
+theorem mk_pnat_denom_dvd (n : ℤ) (d : ℕ+) :
+  (mk_pnat n d).denom ∣ d.1 :=
+begin
+  rw mk_pnat_denom,
+  apply nat.div_dvd_of_dvd,
+  apply nat.gcd_dvd_right
+end
+
+/-* Let $q_1, q_2$, be two raional numbers, then the denominator of $q_1 + q_2$ divides
+the multiplication of their denominators. *-/
+theorem add_denom_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).denom ∣ q₁.denom * q₂.denom :=
+by { cases q₁, cases q₂, apply mk_pnat_denom_dvd }
+
+/-* Let $q_1, q_2$, be two raional numbers, then the denominator of $q_1 * q_2$ divides
+the multiplication of their denominators. *-/
+theorem mul_denom_dvd (q₁ q₂ : ℚ) : (q₁ * q₂).denom ∣ q₁.denom * q₂.denom :=
+by { cases q₁, cases q₂, apply mk_pnat_denom_dvd }
+
+/-* Let $q_1, q_2$, be two raional numbers, then the numerator of $q_1 * q_2$ equals to
+the multiplication of their numerators over the gcd of the multiplication of the numertors and 
+the multiplication of their denominators. *-/
+theorem mul_num (q₁ q₂ : ℚ) : (q₁ * q₂).num =
+  (q₁.num * q₂.num) / nat.gcd (q₁.num * q₂.num).nat_abs (q₁.denom * q₂.denom) :=
+by cases q₁; cases q₂; refl
+
+/-* Let $q_1, q_2$, be two raional numbers, then the denominator of $q_1 * q_2$ equals to
+the multiplication of their denominators over the gcd of the multiplication of the numertors and 
+the multiplication of their denominators. *-/
+theorem mul_denom (q₁ q₂ : ℚ) : (q₁ * q₂).denom =
+  (q₁.denom * q₂.denom) / nat.gcd (q₁.num * q₂.num).nat_abs (q₁.denom * q₂.denom) :=
+by cases q₁; cases q₂; refl
+
+/-* Let $q$ be rational, then the numerator of $q * q$ equals to the square of the numerator of $q$. *-/
+theorem mul_self_num (q : ℚ) : (q * q).num = q.num * q.num :=
+by rw [mul_num, int.nat_abs_mul, nat.coprime.gcd_eq_one, int.coe_nat_one, int.div_one];
+exact (q.cop.mul_right q.cop).mul (q.cop.mul_right q.cop)
+
+/-* Let $q$ be rational, then the denominator of $q * q$ equals to the square of the denominator of $q$. *-/
+theorem mul_self_denom (q : ℚ) : (q * q).denom = q.denom * q.denom :=
+by rw [rat.mul_denom, int.nat_abs_mul, nat.coprime.gcd_eq_one, nat.div_one];
+exact (q.cop.mul_right q.cop).mul (q.cop.mul_right q.cop)
+
+/-* Let $q, r$ be two rational numbers, then $q + r$ equals to
+the sum of numerator of $q$ times denominator of $r$ and denominator of $q$ times numerator of $r$
+over the multiplication of the denominators of $q$ and $r$. *-/
+lemma add_num_denom (q r : ℚ) : q + r =
+  ((q.num * r.denom + q.denom * r.num : ℤ)) /. (↑q.denom * ↑r.denom : ℤ) :=
+have hqd : (q.denom : ℤ) ≠ 0, from int.coe_nat_ne_zero_iff_pos.2 q.3,
+have hrd : (r.denom : ℤ) ≠ 0, from int.coe_nat_ne_zero_iff_pos.2 r.3,
+by conv_lhs { rw [←@num_denom q, ←@num_denom r, rat.add_def hqd hrd] };
+  simp [mul_comm]
+
+section casts
+
+/-* Let $a, b, c$ be three integers, then $a + b$ over $c$ equals to 
+$a / c$ plus $b / c$. *-/
+protected lemma add_mk (a b c : ℤ) : (a + b) /. c = a /. c + b /. c :=
+if h : c = 0 then by simp [h] else
+by { rw [add_def h h, mk_eq h (mul_ne_zero h h)], simp [add_mul, mul_assoc] }
+
+/-* Let $z$ be an integer, then $z$ equals to $z$ over 1. *-/
+theorem coe_int_eq_mk : ∀ (z : ℤ), ↑z = z /. 1
+| (n : ℕ) := show (n:ℚ) = n /. 1,
+  by induction n with n IH n; simp [*, rat.add_mk]
+| -[1+ n] := show (-(n + 1) : ℚ) = -[1+ n] /. 1, begin
+  induction n with n IH, { rw ← of_int_eq_mk, simp, refl },
+  show -(n + 1 + 1 : ℚ) = -[1+ n.succ] /. 1,
+  rw [neg_add, IH, ← mk_neg_one_one],
+  simp [-mk_neg_one_one]
+end
+
+/-* Let $n, d$ be integers, then $n / d$ equals to $n$ as an integer over $d$. *-/
+theorem mk_eq_div (n d : ℤ) : n /. d = ((n : ℚ) / d) :=
+begin
+  by_cases d0 : d = 0, {simp [d0, div_zero]},
+  simp [division_def, coe_int_eq_mk, mul_def one_ne_zero d0]
+end
+
+/-* Let $r$ be an rational number, then its numerator over its denominator equals to $r$ itself. *-/
+@[simp]
+theorem num_div_denom (r : ℚ) : (r.num / r.denom : ℚ) = r :=
+by rw [← int.cast_coe_nat, ← mk_eq_div, num_denom]
+
+/-* Let $n, d$ be nonzero integers, then there exists an integer $c$, such that
+$c$ times the numerator of $n / d$ equals to $n$ and $c$ times the denominator of $n / d$ equals to $c$. *-/
+lemma exists_eq_mul_div_num_and_eq_mul_div_denom {n d : ℤ} (n_ne_zero : n ≠ 0)
+  (d_ne_zero : d ≠ 0) :
+  ∃ (c : ℤ), n = c * ((n : ℚ) / d).num ∧ (d : ℤ) = c * ((n : ℚ) / d).denom :=
+begin
+  have : ((n : ℚ) / d) = rat.mk n d, by rw [←rat.mk_eq_div],
+  exact rat.num_denom_mk n_ne_zero d_ne_zero this
+end
+
+theorem coe_int_eq_of_int (z : ℤ) : ↑z = of_int z :=
+(coe_int_eq_mk z).trans (of_int_eq_mk z).symm
+
+/-* The numerator of an integer is itself. *-/
+@[simp, norm_cast] theorem coe_int_num (n : ℤ) : (n : ℚ).num = n :=
+by rw coe_int_eq_of_int; refl
+
+/-* The denominator of an integer is 1. *-/
+@[simp, norm_cast] theorem coe_int_denom (n : ℤ) : (n : ℚ).denom = 1 :=
+by rw coe_int_eq_of_int; refl
+
+lemma coe_int_num_of_denom_eq_one {q : ℚ} (hq : q.denom = 1) : ↑(q.num) = q :=
+by { conv_rhs { rw [←(@num_denom q), hq] }, rw [coe_int_eq_mk], refl }
+
+lemma denom_eq_one_iff (r : ℚ) : r.denom = 1 ↔ ↑r.num = r :=
+⟨rat.coe_int_num_of_denom_eq_one, λ h, h ▸ rat.coe_int_denom r.num⟩
+
+instance : can_lift ℚ ℤ :=
+⟨coe, λ q, q.denom = 1, λ q hq, ⟨q.num, coe_int_num_of_denom_eq_one hq⟩⟩
+
+theorem coe_nat_eq_mk (n : ℕ) : ↑n = n /. 1 :=
+by rw [← int.cast_coe_nat, coe_int_eq_mk]
+
+@[simp, norm_cast] theorem coe_nat_num (n : ℕ) : (n : ℚ).num = n :=
+by rw [← int.cast_coe_nat, coe_int_num]
+
+@[simp, norm_cast] theorem coe_nat_denom (n : ℕ) : (n : ℚ).denom = 1 :=
+by rw [← int.cast_coe_nat, coe_int_denom]
+
+-- Will be subsumed by `int.coe_inj` after we have defined
+-- `linear_ordered_field ℚ` (which implies characteristic zero).
+lemma coe_int_inj (m n : ℤ) : (m : ℚ) = n ↔ m = n :=
+⟨λ h, by simpa using congr_arg num h, congr_arg _⟩
+
+end casts
+
+/-* Let $q$ be rational, then the inverse of $q$ equals to its denominator over its numerator. *-/
+lemma inv_def' {q : ℚ} : q⁻¹ = (q.denom : ℚ) / q.num :=
+by { conv_lhs { rw ←(@num_denom q) }, cases q, simp [div_num_denom] }
+
+/-* Let $q$ be rational, then $q$ times its denominator equals to its numerator. *-/
+@[simp] lemma mul_denom_eq_num {q : ℚ} : q * q.denom = q.num :=
+begin
+  suffices : mk (q.num) ↑(q.denom) * mk ↑(q.denom) 1 = mk (q.num) 1, by
+  { conv { for q [1] { rw ←(@num_denom q) }}, rwa [coe_int_eq_mk, coe_nat_eq_mk] },
+  have : (q.denom : ℤ) ≠ 0, from ne_of_gt (by exact_mod_cast q.pos),
+  rw [(rat.mul_def this one_ne_zero), (mul_comm (q.denom : ℤ) 1), (div_mk_div_cancel_left this)]
+end
+
+/-* Let $m, n$ be integers, and $n$ is not zero, then the denominator of $m / n$ is one if and only if
+$n$ divides $m$. *-/
+lemma denom_div_cast_eq_one_iff (m n : ℤ) (hn : n ≠ 0) :
+  ((m : ℚ) / n).denom = 1 ↔ n ∣ m :=
+begin
+  replace hn : (n:ℚ) ≠ 0, by rwa [ne.def, ← int.cast_zero, coe_int_inj],
+  split,
+  { intro h,
+    lift ((m : ℚ) / n) to ℤ using h with k hk,
+    use k,
+    rwa [eq_div_iff_mul_eq hn, ← int.cast_mul, mul_comm, eq_comm, coe_int_inj] at hk },
+  { rintros ⟨d, rfl⟩,
+    rw [int.cast_mul, mul_comm, mul_div_cancel _ hn, rat.coe_int_denom] }
+end
+
+/-* Let $a, b$ be integers, $0 < b$, and $a, b$ are coprime. Then the numerator of $a / b$ is $a$. *-/
+lemma num_div_eq_of_coprime {a b : ℤ} (hb0 : 0 < b) (h : nat.coprime a.nat_abs b.nat_abs) :
+  (a / b : ℚ).num = a :=
+begin
+  lift b to ℕ using le_of_lt hb0,
+  norm_cast at hb0 h,
+  rw [← rat.mk_eq_div, ← rat.mk_pnat_eq a b hb0, rat.mk_pnat_num, pnat.mk_coe, h.gcd_eq_one,
+    int.coe_nat_one, int.div_one]
+end
+
+/-* Let $a, b$ be integers, $0 < b$, and $a, b$ are coprime. Then the denominator of $a / b$ is $b$. *-/
+lemma denom_div_eq_of_coprime {a b : ℤ} (hb0 : 0 < b) (h : nat.coprime a.nat_abs b.nat_abs) :
+  ((a / b : ℚ).denom : ℤ) = b :=
+begin
+  lift b to ℕ using le_of_lt hb0,
+  norm_cast at hb0 h,
+  rw [← rat.mk_eq_div, ← rat.mk_pnat_eq a b hb0, rat.mk_pnat_denom, pnat.mk_coe, h.gcd_eq_one,
+    nat.div_one]
+end
+
+/-* Let $a, b, c, d$ be integers, $b, d$ positive, $a, b$ coprime, $c, d$ coprime, and $a / b = c / d$,
+then $a = c$ and $b = d$. *-/
+lemma div_int_inj {a b c d : ℤ} (hb0 : 0 < b) (hd0 : 0 < d)
+  (h1 : nat.coprime a.nat_abs b.nat_abs) (h2 : nat.coprime c.nat_abs d.nat_abs)
+  (h : (a : ℚ) / b = (c : ℚ) / d) : a = c ∧ b = d :=
+begin
+  apply and.intro,
+  { rw [← (num_div_eq_of_coprime hb0 h1), h, num_div_eq_of_coprime hd0 h2] },
+  { rw [← (denom_div_eq_of_coprime hb0 h1), h, denom_div_eq_of_coprime hd0 h2] }
+end
+
+@[norm_cast] lemma coe_int_div_self (n : ℤ) : ((n / n : ℤ) : ℚ) = n / n :=
+begin
+  by_cases hn : n = 0,
+  { subst hn, simp only [int.cast_zero, euclidean_domain.zero_div] },
+  { have : (n : ℚ) ≠ 0, { rwa ← coe_int_inj at hn },
+    simp only [int.div_self hn, int.cast_one, ne.def, not_false_iff, div_self this] }
+end
+
+@[norm_cast] lemma coe_nat_div_self (n : ℕ) : ((n / n : ℕ) : ℚ) = n / n :=
+coe_int_div_self n
+
+lemma coe_int_div (a b : ℤ) (h : b ∣ a) : ((a / b : ℤ) : ℚ) = a / b :=
+begin
+  rcases h with ⟨c, rfl⟩,
+  simp only [mul_comm b, int.mul_div_assoc c (dvd_refl b), int.cast_mul, mul_div_assoc,
+    coe_int_div_self]
+end
+
+lemma coe_nat_div (a b : ℕ) (h : b ∣ a) : ((a / b : ℕ) : ℚ) = a / b :=
+begin
+  rcases h with ⟨c, rfl⟩,
+  simp only [mul_comm b, nat.mul_div_assoc c (dvd_refl b), nat.cast_mul, mul_div_assoc,
+    coe_nat_div_self]
+end
+
+/-* Let $a$ be an positive integer, then the inverse of $a$ has the numerator of 1. *-/
+lemma inv_coe_int_num {a : ℤ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+begin
+  rw [rat.inv_def', rat.coe_int_num, rat.coe_int_denom, nat.cast_one, ←int.cast_one],
+  apply num_div_eq_of_coprime ha0,
+  rw int.nat_abs_one,
+  exact nat.coprime_one_left _,
+end
+
+/-* Let $a$ be an positive natural number, then the inverse of $a$ has the numerator of 1. *-/
+lemma inv_coe_nat_num {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+inv_coe_int_num (by exact_mod_cast ha0 : 0 < (a : ℤ))
+
+/-* Let $a$ be an positive integer, then the denominator of the inverse of $a$ is $a$. *-/
+lemma inv_coe_int_denom {a : ℤ} (ha0 : 0 < a) : ((a : ℚ)⁻¹.denom : ℤ) = a :=
+begin
+  rw [rat.inv_def', rat.coe_int_num, rat.coe_int_denom, nat.cast_one, ←int.cast_one],
+  apply denom_div_eq_of_coprime ha0,
+  rw int.nat_abs_one,
+  exact nat.coprime_one_left _,
+end
+
+/-* Let $a$ be an positive natural number, then the denominator of the inverse of $a$ is $a$. *-/
+lemma inv_coe_nat_denom {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.denom = a :=
+by exact_mod_cast inv_coe_int_denom (by exact_mod_cast ha0 : 0 < (a : ℤ))
+
+protected lemma «forall» {p : ℚ → Prop} : (∀ r, p r) ↔ ∀ a b : ℤ, p (a / b) :=
+⟨λ h _ _, h _,
+  λ h q, (show q = q.num / q.denom, from by simp [rat.div_num_denom]).symm ▸ (h q.1 q.2)⟩
+
+protected lemma «exists» {p : ℚ → Prop} : (∃ r, p r) ↔ ∃ a b : ℤ, p (a / b) :=
+⟨λ ⟨r, hr⟩, ⟨r.num, r.denom, by rwa [← mk_eq_div, num_denom]⟩, λ ⟨a, b, h⟩, ⟨_, h⟩⟩
+
+end rat

--- a/data/rat/order.lean
+++ b/data/rat/order.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import data.rat.basic
+
+/-!
+# Order for Rational Numbers
+
+## Summary
+
+We define the order on `ℚ`, prove that `ℚ` is a discrete, linearly ordered field, and define
+functions such as `abs` and `sqrt` that depend on this order.
+
+## Notations
+
+- `/.` is infix notation for `rat.mk`.
+
+## Tags
+
+rat, rationals, field, ℚ, numerator, denominator, num, denom, order, ordering, sqrt, abs
+-/
+
+namespace rat
+variables (a b c : ℚ)
+open_locale rat
+
+/-- A rational number is called nonnegative if its numerator is nonnegative. -/
+protected def nonneg (r : ℚ) : Prop := 0 ≤ r.num
+
+/-* Let $a, b$ be two integers, and $b$ is positive. Then $a / b$ is non-negative if and only if $a$ is non-negative. *-/
+@[simp] theorem mk_nonneg (a : ℤ) {b : ℤ} (h : 0 < b) : (a /. b).nonneg ↔ 0 ≤ a :=
+begin
+  generalize ha : a /. b = x, cases x with n₁ d₁ h₁ c₁, rw num_denom' at ha,
+  simp [rat.nonneg],
+  have d0 := int.coe_nat_lt.2 h₁,
+  have := (mk_eq (ne_of_gt h) (ne_of_gt d0)).1 ha,
+  constructor; intro h₂,
+  { apply nonneg_of_mul_nonneg_right _ d0,
+    rw this, exact mul_nonneg h₂ (le_of_lt h) },
+  { apply nonneg_of_mul_nonneg_right _ h,
+    rw ← this, exact mul_nonneg h₂ (int.coe_zero_le _) },
+end
+
+/-* The sum of two non-negative rational numbers are non-negative. *-/
+protected lemma nonneg_add {a b} : rat.nonneg a → rat.nonneg b → rat.nonneg (a + b) :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+begin
+  have d₁0 : 0 < (d₁:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
+  have d₂0 : 0 < (d₂:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
+  simp [d₁0, d₂0, h₁, h₂, mul_pos d₁0 d₂0],
+  intros n₁0 n₂0,
+  apply add_nonneg; apply mul_nonneg; {assumption <|> apply int.coe_zero_le},
+end
+
+/-* The multiplication of two non-negative rational numbers are non-negative. *-/
+protected lemma nonneg_mul {a b} : rat.nonneg a → rat.nonneg b → rat.nonneg (a * b) :=
+num_denom_cases_on' a $ λ n₁ d₁ h₁,
+num_denom_cases_on' b $ λ n₂ d₂ h₂,
+begin
+  have d₁0 : 0 < (d₁:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₁),
+  have d₂0 : 0 < (d₂:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h₂),
+  simp [d₁0, d₂0, h₁, h₂, mul_pos d₁0 d₂0, mul_nonneg] { contextual := tt }
+end
+
+/-* Let $a$ be rational, then $a$ is non-negative and $-a$ is non-negative imply that $a$ is zero. *-/
+protected lemma nonneg_antisymm {a} : rat.nonneg a → rat.nonneg (-a) → a = 0 :=
+num_denom_cases_on' a $ λ n d h,
+begin
+  have d0 : 0 < (d:ℤ) := int.coe_nat_pos.2 (nat.pos_of_ne_zero h),
+  simp [d0, h],
+  exact λ h₁ h₂, le_antisymm h₂ h₁
+end
+
+/-* Let $a$ be rational, then $a$ is non-negative or $-a$ is non-negative. *-/
+protected lemma nonneg_total : rat.nonneg a ∨ rat.nonneg (-a) :=
+by cases a with n; exact
+or.imp_right neg_nonneg_of_nonpos (le_total 0 n)
+
+instance decidable_nonneg : decidable (rat.nonneg a) :=
+by cases a; unfold rat.nonneg; apply_instance
+
+/-- Relation `a ≤ b` on `ℚ` defined as `a ≤ b ↔ rat.nonneg (b - a)`. Use `a ≤ b` instead of
+`rat.le a b`. -/
+protected def le (a b : ℚ) := rat.nonneg (b - a)
+
+instance : has_le ℚ := ⟨rat.le⟩
+
+instance decidable_le : decidable_rel ((≤) : ℚ → ℚ → Prop)
+| a b := show decidable (rat.nonneg (b - a)), by apply_instance
+
+/-* Let $a, b, c, d$ be integers, and $b, d$ are positive. Then $a / b$ is lower or equal than $c / d$
+if and ony if $a * d$ is lower of equal than $c * b$. *-/
+protected theorem le_def {a b c d : ℤ} (b0 : 0 < b) (d0 : 0 < d) :
+  a /. b ≤ c /. d ↔ a * d ≤ c * b :=
+begin
+  show rat.nonneg _ ↔ _,
+  rw ← sub_nonneg,
+  simp [sub_eq_add_neg, ne_of_gt b0, ne_of_gt d0, mul_pos d0 b0]
+end
+
+/-* Let $a$ be a rational number, then $a$ is lower or equal to $a$. *-/
+protected theorem le_refl : a ≤ a :=
+show rat.nonneg (a - a), by rw sub_self; exact le_refl (0 : ℤ)
+
+protected theorem le_total : a ≤ b ∨ b ≤ a :=
+by have := rat.nonneg_total (b - a); rwa neg_sub at this
+
+protected theorem le_antisymm {a b : ℚ} (hab : a ≤ b) (hba : b ≤ a) : a = b :=
+by { have := eq_neg_of_add_eq_zero (rat.nonneg_antisymm hba $ by rwa [← sub_eq_add_neg, neg_sub]),
+   rwa neg_neg at this }
+
+protected theorem le_trans {a b c : ℚ} (hab : a ≤ b) (hbc : b ≤ c) : a ≤ c :=
+have rat.nonneg (b - a + (c - b)), from rat.nonneg_add hab hbc,
+by simpa [sub_eq_add_neg, add_comm, add_left_comm]
+
+instance : linear_order ℚ :=
+{ le              := rat.le,
+  le_refl         := rat.le_refl,
+  le_trans        := @rat.le_trans,
+  le_antisymm     := @rat.le_antisymm,
+  le_total        := rat.le_total,
+  decidable_eq    := by apply_instance,
+  decidable_le    := assume a b, rat.decidable_nonneg (b - a) }
+
+/- Extra instances to short-circuit type class resolution -/
+instance : has_lt ℚ          := by apply_instance
+instance : distrib_lattice ℚ := by apply_instance
+instance : lattice ℚ         := by apply_instance
+instance : semilattice_inf ℚ := by apply_instance
+instance : semilattice_sup ℚ := by apply_instance
+instance : has_inf ℚ         := by apply_instance
+instance : has_sup ℚ         := by apply_instance
+instance : partial_order ℚ   := by apply_instance
+instance : preorder ℚ        := by apply_instance
+
+protected lemma le_def' {p q : ℚ} : p ≤ q ↔ p.num * q.denom ≤ q.num * p.denom :=
+begin
+  rw [←(@num_denom q), ←(@num_denom p)],
+  conv_rhs { simp only [num_denom] },
+  exact rat.le_def (by exact_mod_cast p.pos) (by exact_mod_cast q.pos)
+end
+
+protected lemma lt_def {p q : ℚ} : p < q ↔ p.num * q.denom < q.num * p.denom :=
+begin
+  rw [lt_iff_le_and_ne, rat.le_def'],
+  suffices : p ≠ q ↔ p.num * q.denom ≠ q.num * p.denom, by
+  { split; intro h,
+    { exact lt_iff_le_and_ne.elim_right ⟨h.left, (this.elim_left h.right)⟩ },
+    { have tmp := lt_iff_le_and_ne.elim_left h, exact ⟨tmp.left, this.elim_right tmp.right⟩ }},
+  exact (not_iff_not.elim_right eq_iff_mul_eq_mul)
+end
+
+theorem nonneg_iff_zero_le {a} : rat.nonneg a ↔ 0 ≤ a :=
+show rat.nonneg a ↔ rat.nonneg (a - 0), by simp
+
+theorem num_nonneg_iff_zero_le : ∀ {a : ℚ}, 0 ≤ a.num ↔ 0 ≤ a
+| ⟨n, d, h, c⟩ := @nonneg_iff_zero_le ⟨n, d, h, c⟩
+
+protected theorem add_le_add_left {a b c : ℚ} : c + a ≤ c + b ↔ a ≤ b :=
+by unfold has_le.le rat.le; rw add_sub_add_left_eq_sub
+
+protected theorem mul_nonneg {a b : ℚ} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
+by rw ← nonneg_iff_zero_le at ha hb ⊢; exact rat.nonneg_mul ha hb
+
+instance : linear_ordered_field ℚ :=
+{ zero_le_one     := dec_trivial,
+  add_le_add_left := assume a b ab c, rat.add_le_add_left.2 ab,
+  mul_pos         := assume a b ha hb, lt_of_le_of_ne
+    (rat.mul_nonneg (le_of_lt ha) (le_of_lt hb))
+    (mul_ne_zero (ne_of_lt ha).symm (ne_of_lt hb).symm).symm,
+  ..rat.field,
+  ..rat.linear_order,
+  ..rat.semiring }
+
+/- Extra instances to short-circuit type class resolution -/
+instance : linear_ordered_comm_ring ℚ       := by apply_instance
+instance : linear_ordered_ring ℚ            := by apply_instance
+instance : ordered_ring ℚ                   := by apply_instance
+instance : linear_ordered_semiring ℚ        := by apply_instance
+instance : ordered_semiring ℚ               := by apply_instance
+instance : linear_ordered_add_comm_group ℚ  := by apply_instance
+instance : ordered_add_comm_group ℚ         := by apply_instance
+instance : ordered_cancel_add_comm_monoid ℚ := by apply_instance
+instance : ordered_add_comm_monoid ℚ        := by apply_instance
+
+attribute [irreducible] rat.le
+
+theorem num_pos_iff_pos {a : ℚ} : 0 < a.num ↔ 0 < a :=
+lt_iff_lt_of_le_iff_le $
+by simpa [(by cases a; refl : (-a).num = -a.num)]
+   using @num_nonneg_iff_zero_le (-a)
+
+lemma div_lt_div_iff_mul_lt_mul {a b c d : ℤ} (b_pos : 0 < b) (d_pos : 0 < d) :
+  (a : ℚ) / b < c / d ↔ a * d < c * b :=
+begin
+  simp only [lt_iff_le_not_le],
+  apply and_congr,
+  { simp [div_num_denom, (rat.le_def b_pos d_pos)] },
+  { apply not_iff_not_of_iff, simp [div_num_denom, (rat.le_def d_pos b_pos)] }
+end
+
+lemma lt_one_iff_num_lt_denom {q : ℚ} : q < 1 ↔ q.num < q.denom :=
+by simp [rat.lt_def]
+
+theorem abs_def (q : ℚ) : |q| = q.num.nat_abs /. q.denom :=
+begin
+  cases le_total q 0 with hq hq,
+  { rw [abs_of_nonpos hq],
+    rw [←(@num_denom q), ← mk_zero_one, rat.le_def (int.coe_nat_pos.2 q.pos) zero_lt_one,
+        mul_one, zero_mul] at hq,
+    rw [int.of_nat_nat_abs_of_nonpos hq, ← neg_def, num_denom] },
+  { rw [abs_of_nonneg hq],
+    rw [←(@num_denom q), ← mk_zero_one, rat.le_def zero_lt_one (int.coe_nat_pos.2 q.pos),
+        mul_one, zero_mul] at hq,
+    rw [int.nat_abs_of_nonneg hq, num_denom] }
+end
+
+end rat

--- a/data/rat/sqrt.lean
+++ b/data/rat/sqrt.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+
+import data.rat.order
+import data.int.sqrt
+/-!
+# Square root on rational numbers
+
+This file defines the square root function on rational numbers `rat.sqrt`
+and proves several theorems about it.
+
+-/
+namespace rat
+
+/-- Square root function on rational numbers, defined by taking the (integer) square root of the
+numerator and the square root (on natural numbers) of the denominator. -/
+@[pp_nodot] def sqrt (q : ℚ) : ℚ := rat.mk (int.sqrt q.num) (nat.sqrt q.denom)
+
+/-* Let $q$ be rational, then the square root of $q * q$ is $|q|$. *-/
+theorem sqrt_eq (q : ℚ) : rat.sqrt (q*q) = |q| :=
+by rw [sqrt, mul_self_num, mul_self_denom, int.sqrt_eq, nat.sqrt_eq, abs_def]
+
+/-* Let $x$ be rational, then there exists a rational number $q$ such that $q * q$ equals to $x$
+if and only if the square of square root of $x$ equals to $x$. *-/
+theorem exists_mul_self (x : ℚ) : (∃ q, q * q = x) ↔ rat.sqrt x * rat.sqrt x = x :=
+⟨λ ⟨n, hn⟩, by rw [← hn, sqrt_eq, abs_mul_abs_self],
+λ h, ⟨rat.sqrt x, h⟩⟩
+
+/-* Let $q$ be rational, then the square root of $q$ is non negative. *-/
+theorem sqrt_nonneg (q : ℚ) : 0 ≤ rat.sqrt q :=
+nonneg_iff_zero_le.1 $ (mk_nonneg _ $ int.coe_nat_pos.2 $
+nat.pos_of_ne_zero $ λ H, pos_iff_ne_zero.1 q.pos $ nat.sqrt_eq_zero.1 H).2
+$ int.coe_nat_nonneg _
+
+end rat

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -1,0 +1,508 @@
+/-
+Copyright (c) 2018 Mitchell Rowett. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mitchell Rowett, Scott Morrison
+-/
+
+import algebra.quotient
+import group_theory.subgroup.basic
+
+/-!
+# Cosets
+
+This file develops the basic theory of left and right cosets.
+
+## Main definitions
+
+* `left_coset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`, for an
+  `add_group` this is `left_add_coset a s`.
+* `right_coset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`, for an
+  `add_group` this is `right_add_coset s a`.
+* `quotient_group.quotient s`: the quotient type representing the left cosets with respect to a
+  subgroup `s`, for an `add_group` this is `quotient_add_group.quotient s`.
+* `quotient_group.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
+  `add_group` this is `quotient_add_group.mk`.
+* `subgroup.left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup,
+  for an `add_group` this is `add_subgroup.left_coset_equiv_add_subgroup`.
+
+## Notation
+
+* `a *l s`: for `left_coset a s`.
+* `a +l s`: for `left_add_coset a s`.
+* `s *r a`: for `right_coset s a`.
+* `s +r a`: for `right_add_coset s a`.
+
+* `G ⧸ H` is the quotient of the (additive) group `G` by the (additive) subgroup `H`
+
+## TODO
+
+Add `to_additive` to `preimage_mk_equiv_subgroup_times_set`.
+-/
+
+open set function
+
+variable {α : Type*}
+
+/-- The left coset `a * s` for an element `a : α` and a subset `s : set α` -/
+@[to_additive left_add_coset "The left coset `a+s` for an element `a : α`
+and a subset `s : set α`"]
+def left_coset [has_mul α] (a : α) (s : set α) : set α := (λ x, a * x) '' s
+
+/-- The right coset `s * a` for an element `a : α` and a subset `s : set α` -/
+@[to_additive right_add_coset "The right coset `s+a` for an element `a : α`
+and a subset `s : set α`"]
+def right_coset [has_mul α] (s : set α) (a : α) : set α := (λ x, x * a) '' s
+
+localized "infix ` *l `:70 := left_coset" in coset
+localized "infix ` +l `:70 := left_add_coset" in coset
+localized "infix ` *r `:70 := right_coset" in coset
+localized "infix ` +r `:70 := right_add_coset" in coset
+
+section coset_mul
+variable [has_mul α]
+
+/--
+@lemma
+
+-/
+/-* Left coset of `a` contains left multiplication between `a` and set elements. *-/
+@[to_additive mem_left_add_coset]
+lemma mem_left_coset {s : set α} {x : α} (a : α) (hxS : x ∈ s) : a * x ∈ a *l s :=
+mem_image_of_mem (λ b : α, a * b) hxS
+
+@[to_additive mem_right_add_coset]
+lemma mem_right_coset {s : set α} {x : α} (a : α) (hxS : x ∈ s) : x * a ∈ s *r a :=
+mem_image_of_mem (λ b : α, b * a) hxS
+
+/-- Equality of two left cosets `a * s` and `b * s`. -/
+@[to_additive left_add_coset_equivalence "Equality of two left cosets `a + s` and `b + s`."]
+def left_coset_equivalence (s : set α) (a b : α) := a *l s = b *l s
+
+@[to_additive left_add_coset_equivalence_rel]
+lemma left_coset_equivalence_rel (s : set α) : equivalence (left_coset_equivalence s) :=
+mk_equivalence (left_coset_equivalence s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
+
+/-- Equality of two right cosets `s * a` and `s * b`. -/
+@[to_additive right_add_coset_equivalence "Equality of two right cosets `s + a` and `s + b`."]
+def right_coset_equivalence (s : set α) (a b : α) := s *r a = s *r b
+
+@[to_additive right_add_coset_equivalence_rel]
+lemma right_coset_equivalence_rel (s : set α) : equivalence (right_coset_equivalence s) :=
+mk_equivalence (right_coset_equivalence s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
+
+end coset_mul
+
+section coset_semigroup
+variable [semigroup α]
+
+/-* Left coset with factor `b` and `a` consecutively is equal to the left coset with factor `a * b` *-/
+@[simp, to_additive left_add_coset_assoc] lemma left_coset_assoc (s : set α) (a b : α) :
+  a *l (b *l s) = (a * b) *l s :=
+by simp [left_coset, right_coset, (image_comp _ _ _).symm, function.comp, mul_assoc]
+
+@[simp, to_additive right_add_coset_assoc] lemma right_coset_assoc (s : set α) (a b : α) :
+  s *r a *r b = s *r (a * b) :=
+by simp [left_coset, right_coset, (image_comp _ _ _).symm, function.comp, mul_assoc]
+
+@[to_additive left_add_coset_right_add_coset]
+lemma left_coset_right_coset (s : set α) (a b : α) : a *l s *r b = a *l (s *r b) :=
+by simp [left_coset, right_coset, (image_comp _ _ _).symm, function.comp, mul_assoc]
+
+end coset_semigroup
+
+section coset_monoid
+variables [monoid α] (s : set α)
+
+/-* Left coset with unit factor of any set is exactly itself. *-/
+@[simp, to_additive zero_left_add_coset] lemma one_left_coset : 1 *l s = s :=
+set.ext $ by simp [left_coset]
+
+@[simp, to_additive right_add_coset_zero] lemma right_coset_one : s *r 1 = s :=
+set.ext $ by simp [right_coset]
+
+end coset_monoid
+
+section coset_submonoid
+open submonoid
+variables [monoid α] (s : submonoid α)
+
+/-* Left factor is in the left coset of submonoid. *-/
+@[to_additive mem_own_left_add_coset]
+lemma mem_own_left_coset (a : α) : a ∈ a *l s :=
+suffices a * 1 ∈ a *l s, by simpa,
+mem_left_coset a (one_mem s)
+
+@[to_additive mem_own_right_add_coset]
+lemma mem_own_right_coset (a : α) : a ∈ (s : set α) *r a :=
+suffices 1 * a ∈ (s : set α) *r a, by simpa,
+mem_right_coset a (one_mem s)
+
+/-* Only monoid with left factor in it generates left coset same to itself. *-/
+@[to_additive mem_left_add_coset_left_add_coset]
+lemma mem_left_coset_left_coset {a : α} (ha : a *l s = s) : a ∈ s :=
+by rw [←set_like.mem_coe, ←ha]; exact mem_own_left_coset s a
+
+@[to_additive mem_right_add_coset_right_add_coset]
+lemma mem_right_coset_right_coset {a : α} (ha : (s : set α) *r a = s) : a ∈ s :=
+by rw [←set_like.mem_coe, ←ha]; exact mem_own_right_coset s a
+
+end coset_submonoid
+
+section coset_group
+variables [group α] {s : set α} {x : α}
+
+/-* `x` is in the left coset of `s` with left factor `a` if and only if `a^{-1} * x` is in `s`. *-/
+@[to_additive mem_left_add_coset_iff]
+lemma mem_left_coset_iff (a : α) : x ∈ a *l s ↔ a⁻¹ * x ∈ s :=
+iff.intro
+  (assume ⟨b, hb, eq⟩, by simp [eq.symm, hb])
+  (assume h, ⟨a⁻¹ * x, h, by simp⟩)
+
+@[to_additive mem_right_add_coset_iff]
+lemma mem_right_coset_iff (a : α) : x ∈ s *r a ↔ x * a⁻¹ ∈ s :=
+iff.intro
+  (assume ⟨b, hb, eq⟩, by simp [eq.symm, hb])
+  (assume h, ⟨x * a⁻¹, h, by simp⟩)
+
+end coset_group
+
+section coset_subgroup
+open subgroup
+
+variables [group α] (s : subgroup α)
+
+/-* If `a` is in the subgroup `s`, then the left coset of `s` with `a` is `s`. *-/
+@[to_additive left_add_coset_mem_left_add_coset]
+lemma left_coset_mem_left_coset {a : α} (ha : a ∈ s) : a *l s = s :=
+set.ext $ by simp [mem_left_coset_iff, mul_mem_cancel_left s (s.inv_mem ha)]
+
+@[to_additive right_add_coset_mem_right_add_coset]
+lemma right_coset_mem_right_coset {a : α} (ha : a ∈ s) : (s : set α) *r a = s :=
+set.ext $ assume b, by simp [mem_right_coset_iff, mul_mem_cancel_right s (s.inv_mem ha)]
+
+/-* For a normal subgroup, the left coset is euqal to right coset with same factor. *-/
+@[to_additive eq_add_cosets_of_normal]
+theorem eq_cosets_of_normal (N : s.normal) (g : α) : g *l s = s *r g :=
+set.ext $ assume a, by simp [mem_left_coset_iff, mem_right_coset_iff]; rw [N.mem_comm_iff]
+
+/-* A subgroup generating same left coset and right coset with same factor is normal. *-/
+@[to_additive normal_of_eq_add_cosets]
+theorem normal_of_eq_cosets (h : ∀ g : α, g *l s = s *r g) : s.normal :=
+⟨assume a ha g, show g * a * g⁻¹ ∈ (s : set α),
+  by rw [← mem_right_coset_iff, ← h]; exact mem_left_coset g ha⟩
+
+@[to_additive normal_iff_eq_add_cosets]
+theorem normal_iff_eq_cosets : s.normal ↔ ∀ g : α, g *l s = s *r g :=
+⟨@eq_cosets_of_normal _ _ s, normal_of_eq_cosets s⟩
+
+/-* Two left cosets are euqal, if and only if the subgroup contains one factor times the inverse of the other factor. *-/
+@[to_additive left_add_coset_eq_iff]
+lemma left_coset_eq_iff {x y : α} : left_coset x s = left_coset y s ↔ x⁻¹ * y ∈ s :=
+begin
+  rw set.ext_iff,
+  simp_rw [mem_left_coset_iff, set_like.mem_coe],
+  split,
+  { intro h, apply (h y).mpr, rw mul_left_inv, exact s.one_mem },
+  { intros h z, rw ←mul_inv_cancel_right x⁻¹ y, rw mul_assoc, exact s.mul_mem_cancel_left h },
+end
+
+@[to_additive right_add_coset_eq_iff]
+lemma right_coset_eq_iff {x y : α} : right_coset ↑s x = right_coset s y ↔ y * x⁻¹ ∈ s :=
+begin
+  rw set.ext_iff,
+  simp_rw [mem_right_coset_iff, set_like.mem_coe],
+  split,
+  { intro h, apply (h y).mpr, rw mul_right_inv, exact s.one_mem },
+  { intros h z, rw ←inv_mul_cancel_left y x⁻¹, rw ←mul_assoc, exact s.mul_mem_cancel_right h },
+end
+
+end coset_subgroup
+
+run_cmd to_additive.map_namespace `quotient_group `quotient_add_group
+
+namespace quotient_group
+
+variables [group α] (s : subgroup α)
+
+/-- The equivalence relation corresponding to the partition of a group by left cosets
+of a subgroup.-/
+@[to_additive "The equivalence relation corresponding to the partition of a group by left cosets
+of a subgroup."]
+def left_rel : setoid α :=
+⟨λ x y, x⁻¹ * y ∈ s, by { simp_rw ←left_coset_eq_iff, exact left_coset_equivalence_rel s }⟩
+
+lemma left_rel_r_eq_left_coset_equivalence :
+  @setoid.r _ (quotient_group.left_rel s) = left_coset_equivalence s :=
+by { ext, exact (left_coset_eq_iff s).symm }
+
+@[to_additive]
+instance left_rel_decidable [decidable_pred (∈ s)] :
+  decidable_rel (left_rel s).r := λ x y, ‹decidable_pred (∈ s)› _
+
+/-- `α ⧸ s` is the quotient type representing the left cosets of `s`.
+  If `s` is a normal subgroup, `α ⧸ s` is a group -/
+@[to_additive "`α ⧸ s` is the quotient type representing the left cosets of `s`.  If `s` is a
+normal subgroup, `α ⧸ s` is a group"]
+instance : has_quotient α (subgroup α) := ⟨λ s, quotient (left_rel s)⟩
+
+/-- The equivalence relation corresponding to the partition of a group by right cosets of a
+subgroup. -/
+@[to_additive "The equivalence relation corresponding to the partition of a group by right cosets of
+a subgroup."]
+def right_rel : setoid α :=
+⟨λ x y, y * x⁻¹ ∈ s, by { simp_rw ←right_coset_eq_iff, exact right_coset_equivalence_rel s }⟩
+
+lemma right_rel_r_eq_right_coset_equivalence :
+  @setoid.r _ (quotient_group.right_rel s) = right_coset_equivalence s :=
+by { ext, exact (right_coset_eq_iff s).symm }
+
+@[to_additive]
+instance right_rel_decidable [decidable_pred (∈ s)] :
+  decidable_rel (right_rel s).r := λ x y, ‹decidable_pred (∈ s)› _
+
+end quotient_group
+
+namespace quotient_group
+
+variables [group α] {s : subgroup α}
+
+@[to_additive]
+instance fintype [fintype α] (s : subgroup α) [decidable_rel (left_rel s).r] :
+  fintype (α ⧸ s) :=
+quotient.fintype (left_rel s)
+
+/-- The canonical map from a group `α` to the quotient `α ⧸ s`. -/
+@[to_additive "The canonical map from an `add_group` `α` to the quotient `α ⧸ s`."]
+abbreviation mk (a : α) : α ⧸ s :=
+quotient.mk' a
+
+@[to_additive]
+lemma mk_surjective : function.surjective $ @mk _ _ s := quotient.surjective_quotient_mk'
+
+@[elab_as_eliminator, to_additive]
+lemma induction_on {C : α ⧸ s → Prop} (x : α ⧸ s)
+  (H : ∀ z, C (quotient_group.mk z)) : C x :=
+quotient.induction_on' x H
+
+@[to_additive]
+instance : has_coe_t α (α ⧸ s) := ⟨mk⟩ -- note [use has_coe_t]
+
+@[elab_as_eliminator, to_additive]
+lemma induction_on' {C : α ⧸ s → Prop} (x : α ⧸ s)
+  (H : ∀ z : α, C z) : C x :=
+quotient.induction_on' x H
+
+@[simp, to_additive]
+lemma quotient_lift_on_coe {β} (f : α → β) (h) (x : α) :
+  quotient.lift_on' (x : α ⧸ s) f h = f x := rfl
+
+@[to_additive]
+lemma forall_coe {C : α ⧸ s → Prop} :
+  (∀ x : α ⧸ s, C x) ↔ ∀ x : α, C x :=
+⟨λ hx x, hx _, quot.ind⟩
+
+@[to_additive]
+instance (s : subgroup α) : inhabited (α ⧸ s) :=
+⟨((1 : α) : α ⧸ s)⟩
+
+@[to_additive quotient_add_group.eq]
+protected lemma eq {a b : α} : (a : α ⧸ s) = b ↔ a⁻¹ * b ∈ s :=
+quotient.eq'
+
+@[to_additive quotient_add_group.eq']
+lemma eq' {a b : α} : (mk a : α ⧸ s) = mk b ↔ a⁻¹ * b ∈ s :=
+quotient_group.eq
+
+@[to_additive quotient_add_group.out_eq']
+lemma out_eq' (a : α ⧸ s) : mk a.out' = a :=
+quotient.out_eq' a
+
+variables (s)
+
+/- It can be useful to write `obtain ⟨h, H⟩ := mk_out'_eq_mul ...`, and then `rw [H]` or
+  `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
+  stated in terms of an arbitrary `h : s`, rathern that the specific `h = g⁻¹ * (mk g).out'`. -/
+@[to_additive quotient_add_group.mk_out'_eq_mul]
+lemma mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
+⟨⟨g⁻¹ * (mk g).out', eq'.mp (mk g).out_eq'.symm⟩, by rw [s.coe_mk, mul_inv_cancel_left]⟩
+
+variables {s}
+
+@[to_additive quotient_add_group.mk_mul_of_mem]
+lemma mk_mul_of_mem (g₁ g₂ : α) (hg₂ : g₂ ∈ s) : (mk (g₁ * g₂) : α ⧸ s) = mk g₁ :=
+by rwa [eq', mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
+
+@[to_additive]
+lemma eq_class_eq_left_coset (s : subgroup α) (g : α) :
+  {x : α | (x : α ⧸ s) = g} = left_coset g s :=
+set.ext $ λ z,
+  by rw [mem_left_coset_iff, set.mem_set_of_eq, eq_comm, quotient_group.eq, set_like.mem_coe]
+
+@[to_additive]
+lemma preimage_image_coe (N : subgroup α) (s : set α) :
+  coe ⁻¹' ((coe : α → α ⧸ N) '' s) = ⋃ x : N, (λ y : α, y * x) ⁻¹' s :=
+begin
+  ext x,
+  simp only [quotient_group.eq, set_like.exists, exists_prop, set.mem_preimage, set.mem_Union,
+    set.mem_image, subgroup.coe_mk, ← eq_inv_mul_iff_mul_eq],
+  exact ⟨λ ⟨y, hs, hN⟩, ⟨_, N.inv_mem hN, by simpa using hs⟩,
+         λ ⟨z, hz, hxz⟩, ⟨x*z, hxz, by simpa using hz⟩⟩,
+end
+
+end quotient_group
+
+namespace subgroup
+open quotient_group
+variables [group α] {s : subgroup α}
+
+/-- The natural bijection between a left coset `g * s` and `s`. -/
+@[to_additive "The natural bijection between the cosets `g + s` and `s`."]
+def left_coset_equiv_subgroup (g : α) : left_coset g s ≃ s :=
+⟨λ x, ⟨g⁻¹ * x.1, (mem_left_coset_iff _).1 x.2⟩,
+ λ x, ⟨g * x.1, x.1, x.2, rfl⟩,
+ λ ⟨x, hx⟩, subtype.eq $ by simp,
+ λ ⟨g, hg⟩, subtype.eq $ by simp⟩
+
+/-- The natural bijection between a right coset `s * g` and `s`. -/
+@[to_additive "The natural bijection between the cosets `s + g` and `s`."]
+def right_coset_equiv_subgroup (g : α) : right_coset ↑s g ≃ s :=
+⟨λ x, ⟨x.1 * g⁻¹, (mem_right_coset_iff _).1 x.2⟩,
+ λ x, ⟨x.1 * g, x.1, x.2, rfl⟩,
+ λ ⟨x, hx⟩, subtype.eq $ by simp,
+ λ ⟨g, hg⟩, subtype.eq $ by simp⟩
+
+/-- A (non-canonical) bijection between a group `α` and the product `(α/s) × s` -/
+@[to_additive "A (non-canonical) bijection between an add_group `α` and the product `(α/s) × s`"]
+noncomputable def group_equiv_quotient_times_subgroup :
+  α ≃ (α ⧸ s) × s :=
+calc α ≃ Σ L : α ⧸ s, {x : α // (x : α ⧸ s) = L} :
+  (equiv.sigma_preimage_equiv quotient_group.mk).symm
+    ... ≃ Σ L : α ⧸ s, left_coset (quotient.out' L) s :
+  equiv.sigma_congr_right (λ L,
+    begin
+      rw ← eq_class_eq_left_coset,
+      show _root_.subtype (λ x : α, quotient.mk' x = L) ≃
+        _root_.subtype (λ x : α, quotient.mk' x = quotient.mk' _),
+      simp [-quotient.eq'],
+    end)
+    ... ≃ Σ L : α ⧸ s, s :
+  equiv.sigma_congr_right (λ L, left_coset_equiv_subgroup _)
+    ... ≃ (α ⧸ s) × s :
+  equiv.sigma_equiv_prod _ _
+
+variables {t : subgroup α}
+
+/-- If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
+of the quotient map `G → G/K`. The classical version is `quotient_equiv_prod_of_le`. -/
+@[to_additive "If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
+of the quotient map `G → G/K`. The classical version is `quotient_equiv_prod_of_le`.", simps]
+def quotient_equiv_prod_of_le' (h_le : s ≤ t)
+  (f : α ⧸ t → α) (hf : function.right_inverse f quotient_group.mk) :
+  α ⧸ s ≃ (α ⧸ t) × (t ⧸ s.subgroup_of t) :=
+{ to_fun := λ a, ⟨a.map' id (λ b c h, h_le h),
+    a.map' (λ g : α, ⟨(f (quotient.mk' g))⁻¹ * g, quotient.exact' (hf g)⟩) (λ b c h, by
+    { change ((f b)⁻¹ * b)⁻¹ * ((f c)⁻¹ * c) ∈ s,
+      have key : f b = f c := congr_arg f (quotient.sound' (h_le h)),
+      rwa [key, mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_left] })⟩,
+  inv_fun := λ a, a.2.map' (λ b, f a.1 * b) (λ b c h, by
+  { change (f a.1 * b)⁻¹ * (f a.1 * c) ∈ s,
+    rwa [mul_inv_rev, mul_assoc, inv_mul_cancel_left] }),
+  left_inv := by
+  { refine quotient.ind' (λ a, _),
+    simp_rw [quotient.map'_mk', id.def, t.coe_mk, mul_inv_cancel_left] },
+  right_inv := by
+  { refine prod.rec _,
+    refine quotient.ind' (λ a, _),
+    refine quotient.ind' (λ b, _),
+    have key : quotient.mk' (f (quotient.mk' a) * b) = quotient.mk' a :=
+      (quotient_group.mk_mul_of_mem (f a) ↑b b.2).trans (hf a),
+    simp_rw [quotient.map'_mk', id.def, key, inv_mul_cancel_left, subtype.coe_eta] } }
+
+/-- If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively.
+The constructive version is `quotient_equiv_prod_of_le'`. -/
+@[to_additive "If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively.
+The constructive version is `quotient_equiv_prod_of_le'`.", simps]
+noncomputable def quotient_equiv_prod_of_le (h_le : s ≤ t) :
+  α ⧸ s ≃ (α ⧸ t) × (t ⧸ s.subgroup_of t) :=
+quotient_equiv_prod_of_le' h_le quotient.out' quotient.out_eq'
+
+/-- If `K ≤ L`, then there is an embedding `K ⧸ (H.subgroup_of K) ↪ L ⧸ (H.subgroup_of L)`. -/
+def quotient_subgroup_of_embedding_of_le (H : subgroup α) {K L : subgroup α} (h : K ≤ L) :
+  K ⧸ (H.subgroup_of K) ↪ L ⧸ (H.subgroup_of L) :=
+{ to_fun := quotient.map' (set.inclusion h) (λ a b, id),
+  inj' := by refine quotient.ind₂' (λ a b, _); exact quotient.eq'.mpr ∘ quotient.eq'.mp }
+
+@[to_additive] lemma card_eq_card_quotient_mul_card_subgroup
+  [fintype α] (s : subgroup α) [fintype s] [decidable_pred (λ a, a ∈ s)] :
+  fintype.card α = fintype.card (α ⧸ s) * fintype.card s :=
+by rw ← fintype.card_prod;
+  exact fintype.card_congr (subgroup.group_equiv_quotient_times_subgroup)
+
+/-- **Lagrange's Theorem**: The order of a subgroup divides the order of its ambient group. -/
+/-* The order of a subgroup divides the order of its ambient group. *-/
+@[to_additive] lemma card_subgroup_dvd_card [fintype α] (s : subgroup α) [fintype s] :
+  fintype.card s ∣ fintype.card α :=
+by classical; simp [card_eq_card_quotient_mul_card_subgroup s, @dvd_mul_left ℕ]
+
+@[to_additive] lemma card_quotient_dvd_card [fintype α] (s : subgroup α)
+  [decidable_pred (λ a, a ∈ s)] [fintype s] : fintype.card (α ⧸ s) ∣ fintype.card α :=
+by simp [card_eq_card_quotient_mul_card_subgroup s, @dvd_mul_right ℕ]
+
+open fintype
+
+variables {H : Type*} [group H]
+
+@[to_additive] lemma card_dvd_of_injective [fintype α] [fintype H] (f : α →* H)
+  (hf : function.injective f) : card α ∣ card H :=
+by classical;
+calc card α = card (f.range : subgroup H) : card_congr (equiv.of_injective f hf)
+...∣ card H : card_subgroup_dvd_card _
+
+@[to_additive] lemma card_dvd_of_le {H K : subgroup α} [fintype H] [fintype K] (hHK : H ≤ K) :
+  card H ∣ card K :=
+card_dvd_of_injective (inclusion hHK) (inclusion_injective hHK)
+
+@[to_additive] lemma card_comap_dvd_of_injective (K : subgroup H) [fintype K]
+  (f : α →* H) [fintype (K.comap f)] (hf : function.injective f) :
+  fintype.card (K.comap f) ∣ fintype.card K :=
+by haveI : fintype ((K.comap f).map f) :=
+  fintype.of_equiv _ (equiv_map_of_injective _ _ hf).to_equiv;
+calc fintype.card (K.comap f) = fintype.card ((K.comap f).map f) :
+       fintype.card_congr (equiv_map_of_injective _ _ hf).to_equiv
+... ∣ fintype.card K : card_dvd_of_le (map_comap_le _ _)
+
+end subgroup
+
+namespace quotient_group
+
+variables [group α]
+
+-- FIXME -- why is there no `to_additive`?
+
+/-- If `s` is a subgroup of the group `α`, and `t` is a subset of `α/s`, then
+there is a (typically non-canonical) bijection between the preimage of `t` in
+`α` and the product `s × t`. -/
+noncomputable def preimage_mk_equiv_subgroup_times_set
+  (s : subgroup α) (t : set (α ⧸ s)) : quotient_group.mk ⁻¹' t ≃ s × t :=
+have h : ∀ {x : α ⧸ s} {a : α}, x ∈ t → a ∈ s →
+  (quotient.mk' (quotient.out' x * a) : α ⧸ s) = quotient.mk' (quotient.out' x) :=
+    λ x a hx ha, quotient.sound' (show (quotient.out' x * a)⁻¹ * quotient.out' x ∈ s,
+      from (s.inv_mem_iff).1 $
+        by rwa [mul_inv_rev, inv_inv, ← mul_assoc, inv_mul_self, one_mul]),
+{ to_fun := λ ⟨a, ha⟩, ⟨⟨(quotient.out' (quotient.mk' a))⁻¹ * a,
+    @quotient.exact' _ (left_rel s) _ _ $ (quotient.out_eq' _)⟩,
+      ⟨quotient.mk' a, ha⟩⟩,
+  inv_fun := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, ⟨quotient.out' x * a, show quotient.mk' _ ∈ t,
+    by simp [h hx ha, hx]⟩,
+  left_inv := λ ⟨a, ha⟩, subtype.eq $ show _ * _ = a, by simp,
+  right_inv := λ ⟨⟨a, ha⟩, ⟨x, hx⟩⟩, show (_, _) = _, by simp [h hx ha] }
+
+end quotient_group
+
+/--
+We use the class `has_coe_t` instead of `has_coe` if the first argument is a variable,
+or if the second argument is a variable not occurring in the first.
+Using `has_coe` would cause looping of type-class inference. See
+<https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/remove.20all.20instances.20with.20variable.20domain>
+-/
+library_note "use has_coe_t"

--- a/group_theory/torsion.lean
+++ b/group_theory/torsion.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2022 Julian Berman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Berman
+-/
+
+import group_theory.exponent
+import group_theory.order_of_element
+import group_theory.quotient_group
+
+/-!
+# Torsion groups
+
+This file defines torsion groups, i.e. groups where all elements have finite order.
+
+## Main definitions
+
+* `monoid.is_torsion` is a predicate asserting a monoid `G` is a torsion monoid, i.e. that all
+  elements are of finite order. Torsion groups are also known as periodic groups.
+* `add_monoid.is_torsion` the additive version of `monoid.is_torsion`.
+
+## Future work
+
+* Define `tor G` for the torsion subgroup of a group
+* torsion-free groups
+-/
+
+universe u
+
+variable {G : Type u}
+
+open_locale classical
+
+namespace monoid
+
+variables (G) [monoid G]
+
+/--A predicate on a monoid saying that all elements are of finite order.-/
+@[to_additive "A predicate on an additive monoid saying that all elements are of finite order."]
+def is_torsion := ∀ g : G, is_of_fin_order g
+
+end monoid
+
+open monoid
+
+/-- Torsion monoids are really groups. -/
+@[to_additive "Torsion additive monoids are really additive groups"]
+noncomputable def is_torsion.group [monoid G] (tG : is_torsion G) : group G :=
+{ inv := λ g, g ^ (order_of g - 1),
+  mul_left_inv := λ g,
+  begin
+    erw [←pow_succ', tsub_add_cancel_of_le, pow_order_of_eq_one],
+    exact order_of_pos' (tG g)
+  end,
+  ..‹monoid G› }
+
+variables [group G] {N : subgroup G}
+
+/-* Subgroups of torsion groups are torsion groups. *-/
+@[to_additive "Subgroups of additive torsion groups are additive torsion groups."]
+lemma is_torsion.subgroup (tG : is_torsion G) (H : subgroup G) : is_torsion H :=
+λ h, (is_of_fin_order_iff_coe _ h).mpr $ tG h
+
+/-* Quotient groups of torsion groups are torsion groups. *-/
+@[to_additive "Quotient groups of additive torsion groups are additive torsion groups."]
+lemma is_torsion.quotient_group [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
+λ h, quotient_group.induction_on' h $ λ g, (tG g).quotient N g
+
+/-* If a group exponent exists, the group is torsion. *-/
+@[to_additive exponent_exists.is_add_torsion]
+lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
+  obtain ⟨n, npos, hn⟩ := h,
+  intro g,
+  exact (is_of_fin_order_iff_pow_eq_one g).mpr ⟨n, npos, hn g⟩,
+end
+
+/-* The group exponent exists for any bounded torsion group. *-/
+@[to_additive is_add_torsion.exponent_exists]
+lemma is_torsion.exponent_exists
+  (tG : is_torsion G) (bounded : (set.range (λ g : G, order_of g)).finite) :
+  exponent_exists G :=
+exponent_exists_iff_ne_zero.mpr $
+  (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
+
+/-* Finite groups are torsion groups. *-/
+@[to_additive is_add_torsion_of_fintype]
+lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
+exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype


### PR DESCRIPTION
Three lean files in `data/nat` have been labeled:
- `data/nat/basic.lean` with 72 annotations
- `data/nat/sqrt.lean` with 3 annotations
- `data/nat/order.lean` with 7 annotations
